### PR TITLE
Don't validate jwt when getting app instance

### DIFF
--- a/lib/atomic_tenant/current_application_instance_middleware.rb
+++ b/lib/atomic_tenant/current_application_instance_middleware.rb
@@ -57,14 +57,15 @@ module AtomicTenant
           env['atomic.validated.application_instance_id'] = app_instance.id
         elsif encoded_token(request).present?
           token = encoded_token(request)
-          # TODO: decoded token should be put on request
-          decoded_token = AtomicTenant::JwtToken.decode(token)
+          # We don't validate the token here because this step is only designed to set
+          # the tenant for the request. If the token is invalid or expired the app must
+          # return 401 or take other action.
+          decoded_token = AtomicTenant::JwtToken.decode(token, validate: false)
           if decoded_token.present? && decoded_token.first.present?
             if app_instance_id = decoded_token.first['application_instance_id']
               env['atomic.validated.application_instance_id'] = app_instance_id
             end
           end
-
         end
 
       rescue StandardError => e

--- a/lib/atomic_tenant/jwt_token.rb
+++ b/lib/atomic_tenant/jwt_token.rb
@@ -4,7 +4,7 @@ module AtomicTenant
 
     ALGORITHM = "HS512".freeze
 
-    def self.decode(token,  algorithm: ALGORITHM, validate: true)
+    def self.decode(token,  algorithm = ALGORITHM, validate: true)
       decoded_token = JWT.decode(
         token,
         AtomicTenant.jwt_secret,

--- a/lib/atomic_tenant/jwt_token.rb
+++ b/lib/atomic_tenant/jwt_token.rb
@@ -1,17 +1,19 @@
 module AtomicTenant
   module JwtToken
     class InvalidTokenError < StandardError; end
- 
+
     ALGORITHM = "HS512".freeze
 
-    def self.decode(token,  algorithm = ALGORITHM)
+    def self.decode(token,  algorithm: ALGORITHM, validate: true)
       decoded_token = JWT.decode(
         token,
         AtomicTenant.jwt_secret,
-        true,
+        validate,
         { algorithm: algorithm },
       )
-      raise InvalidTokenError if AtomicTenant.jwt_aud != decoded_token[0]["aud"]
+      if AtomicTenant.jwt_aud != decoded_token[0]["aud"]
+        return nil
+      end
 
       decoded_token
     end


### PR DESCRIPTION
The app should be responsible for validating the jwt and returning a 401 if it's not valid.  This is to fix a bug where an expired jwt was returning a 500 from middleware for tenant not found rather than the proper 401 result to indicate a new jwt is needed.  The middleware is not aware of which paths need authentication, so it's not the correct place to fail a request because of expired credentials.