### PR TITLE
Leave validation of course copy token up to the app

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    atomic_tenant (1.2.1)
+    atomic_tenant (1.2.2)
       atomic_lti (~> 1.3)
       rails (~> 7.0)
 
@@ -73,16 +73,16 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-    atomic_lti (1.5.3)
+    atomic_lti (1.8.0)
       pg (~> 1.3)
       rails (~> 7.0)
     builder (3.2.4)
     concurrent-ruby (1.2.2)
     crass (1.0.6)
-    date (3.3.3)
+    date (3.3.4)
     erubi (1.12.0)
-    globalid (1.1.0)
-      activesupport (>= 5.0)
+    globalid (1.2.1)
+      activesupport (>= 6.1)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     loofah (2.21.3)
@@ -97,21 +97,21 @@ GEM
     method_source (1.0.0)
     mini_mime (1.1.5)
     minitest (5.19.0)
-    net-imap (0.3.7)
+    net-imap (0.4.9.1)
       date
       net-protocol
     net-pop (0.1.2)
       net-protocol
-    net-protocol (0.2.1)
+    net-protocol (0.2.2)
       timeout
-    net-smtp (0.3.3)
+    net-smtp (0.4.0.1)
       net-protocol
-    nio4r (2.5.9)
+    nio4r (2.7.0)
     nokogiri (1.15.3-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.15.3-x86_64-linux)
       racc (~> 1.4)
-    pg (1.5.3)
+    pg (1.5.4)
     racc (1.7.1)
     rack (2.2.8)
     rack-test (2.1.0)
@@ -144,7 +144,7 @@ GEM
       rake (>= 12.2)
       thor (~> 1.0)
       zeitwerk (~> 2.5)
-    rake (13.0.6)
+    rake (13.1.0)
     sprockets (4.2.0)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -154,14 +154,14 @@ GEM
       sprockets (>= 3.0.0)
     sqlite3 (1.6.3-x86_64-darwin)
     sqlite3 (1.6.3-x86_64-linux)
-    thor (1.2.2)
-    timeout (0.4.0)
+    thor (1.3.0)
+    timeout (0.4.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    zeitwerk (2.6.11)
+    zeitwerk (2.6.12)
 
 PLATFORMS
   x86_64-darwin-22

--- a/lib/atomic_tenant/canvas_content_migration.rb
+++ b/lib/atomic_tenant/canvas_content_migration.rb
@@ -12,13 +12,9 @@ module AtomicTenant
       unverified = JWT.decode(token, nil, false)
       kid = unverified[HEADER]["kid"]
       app_instance = ApplicationInstance.find_by!(lti_key: kid)
-      decoded_token = JWT.decode(
-        token,
-        app_instance.lti_secret,
-        true,
-        { algorithm: algorithm },
-      )
-      [decoded_token, app_instance]
+      # Don't validate because we're only setting the tenant for the request. The app
+      # must validate the JWT.
+      [nil, app_instance]
     end
   end
 end

--- a/lib/atomic_tenant/canvas_content_migration.rb
+++ b/lib/atomic_tenant/canvas_content_migration.rb
@@ -12,9 +12,9 @@ module AtomicTenant
       unverified = JWT.decode(token, nil, false)
       kid = unverified[HEADER]["kid"]
       app_instance = ApplicationInstance.find_by!(lti_key: kid)
-      # Don't validate because we're only setting the tenant for the request. The app
+      # We don't validate because we're only setting the tenant for the request. The app
       # must validate the JWT.
-      [nil, app_instance]
+      app_instance
     end
   end
 end

--- a/lib/atomic_tenant/current_application_instance_middleware.rb
+++ b/lib/atomic_tenant/current_application_instance_middleware.rb
@@ -53,7 +53,7 @@ module AtomicTenant
             env['atomic.validated.application_instance_id'] = instance.id
           end
         elsif canvas_migration_hook?(request)
-          _token, app_instance = AtomicTenant::CanvasContentMigration.decode(encoded_token(request))
+          app_instance = AtomicTenant::CanvasContentMigration.decode(encoded_token(request))
           env['atomic.validated.application_instance_id'] = app_instance.id
         elsif encoded_token(request).present?
           token = encoded_token(request)

--- a/lib/atomic_tenant/version.rb
+++ b/lib/atomic_tenant/version.rb
@@ -1,3 +1,3 @@
 module AtomicTenant
-  VERSION = '1.2.1'
+  VERSION = '1.2.2'
 end


### PR DESCRIPTION
The rails app itself needs to validate the token.  The tenant middleware is just concerned with finding an application instance.
