### PR TITLE
Add column to track when we registered pns notifications

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    atomic_tenant (1.2.2)
+    atomic_tenant (1.3.0)
       atomic_lti (~> 1.3)
       rails (~> 7.0)
 
@@ -82,7 +82,7 @@ GEM
       minitest (>= 5.1)
       mutex_m
       tzinfo (~> 2.0)
-    atomic_lti (1.8.0)
+    atomic_lti (1.9.0)
       pg (~> 1.3)
       rails (~> 7.0)
     base64 (0.2.0)
@@ -130,7 +130,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.16.6-x86_64-linux)
       racc (~> 1.4)
-    pg (1.5.4)
+    pg (1.5.6)
     psych (5.1.2)
       stringio
     racc (1.8.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,6 +124,8 @@ GEM
     net-smtp (0.5.0)
       net-protocol
     nio4r (2.7.3)
+    nokogiri (1.16.6-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.16.6-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.16.6-x86_64-linux)
@@ -181,6 +183,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    sqlite3 (1.6.3-arm64-darwin)
     sqlite3 (1.6.3-x86_64-darwin)
     sqlite3 (1.6.3-x86_64-linux)
     stringio (3.1.1)
@@ -195,6 +198,7 @@ GEM
     zeitwerk (2.6.16)
 
 PLATFORMS
+  arm64-darwin-23
   x86_64-darwin-22
   x86_64-linux
 

--- a/db/migrate/20240704002449_add_atomic_tenant_lti_deployment_platform_notification_status.rb
+++ b/db/migrate/20240704002449_add_atomic_tenant_lti_deployment_platform_notification_status.rb
@@ -1,0 +1,5 @@
+class AddAtomicTenantLtiDeploymentPlatformNotificationStatus < ActiveRecord::Migration[7.1]
+  def change
+    add_column :atomic_tenant_lti_deployments, :registered_pns_notifications_at, :timestamptz
+  end
+end

--- a/lib/atomic_tenant/version.rb
+++ b/lib/atomic_tenant/version.rb
@@ -1,3 +1,3 @@
 module AtomicTenant
-  VERSION = '1.2.2'
+  VERSION = '1.3.0'
 end


### PR DESCRIPTION
This will let us register for platform notifications when we get the first launch in a deployment and track that we have done it.