### PR TITLE
Require Rails 7.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     atomic_tenant (1.3.0)
       atomic_lti (~> 1.3)
-      rails (~> 7.0)
+      rails (~> 7.1)
 
 GEM
   remote: https://rubygems.org/

--- a/atomic_tenant.gemspec
+++ b/atomic_tenant.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
     Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
   end
 
-  spec.add_dependency 'atomic_lti', '~> 1.3'
-  spec.add_dependency "rails", "~> 7.0"
+  spec.add_dependency 'atomic_lti', '~> 2.0'
+  spec.add_dependency "rails", "~> 7.1"
 
 end


### PR DESCRIPTION
atomic_lti 2.0 will not be compatible with Rails 7.0, due to not being able to use composite_primary_keys anymore.